### PR TITLE
[security patch][discard more bytes - hackers.mu]

### DIFF
--- a/FPJumper/Assets/UniWeb/Plugins/HTTP/Arc4RandomNumberGenerator.cs
+++ b/FPJumper/Assets/UniWeb/Plugins/HTTP/Arc4RandomNumberGenerator.cs
@@ -60,7 +60,7 @@ public class Arc4RandomNumberGenerator {
 
     	// Discard early keystream, as per recommendations in:
     	// http://www.wisdom.weizmann.ac.il/~itsik/RC4/Papers/Rc4_ksa.ps
-    	for (int i = 0; i < 256; i++)
+    	for (int i = 0; i < 3072; i++)
         	GetByte();
     	count = STIR_INCREMENT_CONST;
 	}


### PR DESCRIPTION
This follows the recommendations outlined in Network Operations Division
Cryptographic Requirements published on wikileaks on March 2017.
We discard more bytes of the first keystream to reduce possibility of
non-random bytes.